### PR TITLE
gh-aw: init at 0.68.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,8 @@
 
   docker-sandboxes = pkgs.callPackage ./pkgs/docker-sandboxes { };
   multica = pkgs.callPackage ./pkgs/multica { };
+  gh-aw = pkgs.callPackage ./pkgs/gh-aw { };
+  
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...
 }

--- a/pkgs/gh-aw/default.nix
+++ b/pkgs/gh-aw/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gh-aw";
+  version = "0.68.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "github";
+    repo = "gh-aw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P3psfcuzLJ0W+3iJbPI7lfWiy8CIfZsYyY/4bcLEEjs=";
+  };
+
+  vendorHash = "sha256-1BMh4mC62usE4pUCU5osHm1a1pBrXsp4YCumvvcAHIY=";
+
+  subPackages = [ "cmd/gh-aw" ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    homepage = "https://github.com/github/gh-aw";
+    description = "gh extension for GitHub Agentic Workflows";
+    longDescription = ''
+      Repository automation, running the coding agents you know and
+      love, with strong guardrails in GitHub Actions.
+    '';
+    changelog = "https://github.com/github/gh-aw/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/github/gh-aw/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ MH0386 ];
+    mainProgram = "gh-aw";
+  };
+})


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a gh-aw Go module package built from the upstream GitHub repository at version 0.68.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gh-aw` package (version 0.68.3) to available tools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MH0386/nurpkgs/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->