### PR TITLE
ntn: init at 0.13.2

### DIFF
--- a/.github/workflows/.update.yaml
+++ b/.github/workflows/.update.yaml
@@ -32,8 +32,10 @@ jobs:
           git config user.name "Mohamed Hisham Abdelzaher"
           git config user.email "mohamed.hisham.abdelzaher@gmail.com"
       - name: Update
+        env:
+          NIXPKGS_ALLOW_UNFREE: "1"
         run: >-
           nix shell nixpkgs#nix-update nixpkgs#jq -c sh -lc
-          "nix eval --json .#packages.x86_64-linux | jq -r 'keys[]' | xargs -r -n1 nix-update --commit"
+          "nix eval --impure --json .#packages.x86_64-linux | jq -r 'keys[]' | xargs -r -n1 nix-update --commit"
       - name: Push changes
         run: git push --no-verify

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@
   multica = pkgs.callPackage ./pkgs/multica { };
   gh-aw = pkgs.callPackage ./pkgs/gh-aw { };
   tinyfish = pkgs.callPackage ./pkgs/tinyfish { };
+  ntn = pkgs.callPackage ./pkgs/ntn { };
 
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...

--- a/pkgs/ntn/default.nix
+++ b/pkgs/ntn/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  versionCheckHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ntn";
+  version = "0.13.2";
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "ntn is not supported on ${stdenvNoCC.hostPlatform.system}");
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ntn $out/bin/ntn
+    install -Dm644 README.md $out/share/doc/${finalAttrs.pname}/README.md
+    install -Dm644 LICENSE.md $out/share/licenses/${finalAttrs.pname}/LICENSE.md
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      x86_64-linux = fetchurl {
+        url = "https://ntn.dev/releases/v${finalAttrs.version}/ntn-x86_64-unknown-linux-musl.tar.gz";
+        hash = "sha256-RLvPkeETvTPvUnXR7kUWD0RjvdrlO+rrOBJz95fTSck=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://ntn.dev/releases/v${finalAttrs.version}/ntn-aarch64-unknown-linux-musl.tar.gz";
+        hash = "sha256-Ica1fdfn2/i9ZTGRs7jAwBQgQsJJOeurRgSKe58i4uc=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "https://ntn.dev/releases/v${finalAttrs.version}/ntn-x86_64-apple-darwin.tar.gz";
+        hash = "sha256-GN1vbCidJPbvYJFgkj1MoC9m6kaRC0X+rkSgKAltclQ=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "https://ntn.dev/releases/v${finalAttrs.version}/ntn-aarch64-apple-darwin.tar.gz";
+        hash = "sha256-QM5e10kPk3G8UqKJGHI/XCAQv32benswJz2LY7MNUFQ=";
+      };
+    };
+  };
+
+  meta = {
+    description = "CLI for Notion";
+    homepage = "https://www.notion.dev";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.MH0386 ];
+    mainProgram = "ntn";
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
+  };
+})


### PR DESCRIPTION
## Summary by Sourcery

Add a new Nix package for the prebuilt `ntn` CLI and expose it in the package set.

New Features:
- Introduce the `ntn` CLI package using prebuilt binaries for Linux and macOS across common architectures.

Enhancements:
- Define metadata, licensing, and platform support for the `ntn` package, including passthrough source URLs per platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `ntn` CLI tool version 0.13.2, now available for installation with prebuilt binaries for multiple platforms. Installation includes automatic verification and comprehensive documentation and licensing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MH0386/nurpkgs/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->